### PR TITLE
[FIX][TKT4670] - l10n_ar_account_tax_settlement

### DIFF
--- a/l10n_ar_account_tax_settlement/README.rst
+++ b/l10n_ar_account_tax_settlement/README.rst
@@ -85,3 +85,10 @@ Maintainer
 This module is maintained by the |company|.
 
 To contribute to this module, please visit https://www.adhoc.com.ar.
+
+Changelog
+=========
+
+15.0.1.7.1
+----------
+* Fix: Normalizar documento cuando falta l10n_latam_document_type_id

--- a/l10n_ar_account_tax_settlement/__manifest__.py
+++ b/l10n_ar_account_tax_settlement/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Tax Settlements For Argentina',
-    'version': "15.0.1.7.0",
+    'version': "15.0.1.7.1",
     'category': 'Accounting',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -766,8 +766,25 @@ class AccountJournal(models.Model):
                     internal_type == 'credit_note' and 'C' or
                     internal_type == 'debit_note' and 'D' or 'R')
                 content += line.l10n_latam_document_type_id.l10n_ar_letter
+            # Fix: Normalizar documento cuando falta l10n_latam_document_type_id
+            
+            document_number = move.l10n_latam_document_number or move.name or ''
+            normalized_document_number = document_number
+            
+            if document_number and '-' in document_number:
+                parts = document_number.split('-')
+                if len(parts) > 2:
+                    numeric_parts = []
+                    for part in parts:
+                        digits = re.sub(r'\D', '', part)
+                        if digits:
+                            numeric_parts.append(digits)
+                    if len(numeric_parts) >= 2:
+                        normalized_document_number = f"{numeric_parts[-2]}-{numeric_parts[-1]}"
+            
+            document_type_code = move.l10n_latam_document_type_id.code if move.l10n_latam_document_type_id else None
             document_parts = move._l10n_ar_get_document_number_parts(
-                move.l10n_latam_document_number, move.l10n_latam_document_type_id.code)
+                normalized_document_number, document_type_code)
             # si el punto de venta es de 5 digitos no encontramos doc
             # que diga como proceder, tomamos los ultimos 4 digitos
             pto_venta = "{:0>4d}".format(document_parts['point_of_sale'])[-4:]


### PR DESCRIPTION
Fix issue in tax settlement TXT generation where the process failed if `l10n_latam_document_type_id` was missing on the move.

Changes:
- Implemented document number normalization logic to safely extract Point of Sale and Invoice Number using regex, even from non-standard strings or `move.name`.
- Added fallback handling when document type is None.
- Bump version to 15.0.1.7.1.